### PR TITLE
fix beam centering when in_height does not equal cn_lego_pitch_stud

### DIFF
--- a/customizable_straight_beam_v4o.scad
+++ b/customizable_straight_beam_v4o.scad
@@ -100,7 +100,7 @@ module lego_beam( is_holes, in_height = cn_lego_height_beam, in_margin = 0.0  )
 	if (in_length > 0)
 	{
 		//Center the beam
-		translate([0,cn_lego_pitch_stud,0])
+		translate([0,in_height,0])
 		rotate([90,0,0])
 		difference()
 		{


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
For cases where in_height does not equal cn_lego_pitch_stud, the centering in lego_beam is inaccurate. Fix this so that in_height is used for centering, so centering is accurate.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
