### PR TITLE
Move precision to global so it can be overwritten by calling script

### DIFF
--- a/customizable_straight_beam_v4o.scad
+++ b/customizable_straight_beam_v4o.scad
@@ -100,7 +100,7 @@ module lego_beam( is_holes, in_height = cn_lego_height_beam, in_margin = 0.0  )
 	if (in_length > 0)
 	{
 		//Center the beam
-		translate([0,cn_lego_pitch_stud,0])
+		translate([0,in_height,0])
 		rotate([90,0,0])
 		difference()
 		{

--- a/customizable_straight_beam_v4o.scad
+++ b/customizable_straight_beam_v4o.scad
@@ -21,7 +21,8 @@
 		2024-08-04 there is an asymmetry in the hole, the oPo shows there should be a thin bodred above the hole
 */
 
-
+$fa = $preview ? 2:.5;
+$fs = $preview ? .5:0.35;
 
 // user parameters
 
@@ -46,18 +47,18 @@ cn_lego_drill_depth_indent = 0.5;
 //How steep the transition from big hole to small hole
 cn_lego_drill_sharpness = 0.5;
 
-module body( in_length_stud, in_height = cn_lego_height_beam, in_precision = 0.5 )
+module body( in_length_stud, in_height = cn_lego_height_beam)
 {
     translate([0, cn_lego_width_beam/2, 0]) 
     hull()
 	{
-        cylinder(r=cn_lego_width_beam/2, h=in_height,$fa = 0.1+in_precision, $fs = 0.1+in_precision/2);    
+        cylinder(r=cn_lego_width_beam/2, h=in_height);
         translate([(in_length_stud-1)*cn_lego_pitch_stud, 0, 0]) 
-            cylinder(r=cn_lego_width_beam/2, h=in_height,$fa = 0.1+in_precision, $fs = 0.1+in_precision/2);
+            cylinder(r=cn_lego_width_beam/2, h=in_height);
     }
 }
 
-module hole( in_height = cn_lego_height_beam, in_precision = 0.5, in_margin = 0.0 )
+module hole( in_height = cn_lego_height_beam, in_margin = 0.0)
 {
 	an_cross_section = [
 		//Bottom
@@ -76,11 +77,11 @@ module hole( in_height = cn_lego_height_beam, in_precision = 0.5, in_margin = 0.
 		[(cn_lego_drill_large+in_margin)/2,0]
 	];
 	//Rotate the cross section of the hole around its axis, to generate the hole
-	rotate_extrude($fa = 0.1+in_precision, $fs = 0.1+in_precision/2)
-	polygon(an_cross_section);
+	rotate_extrude()
+		polygon(an_cross_section);
 }
 
-module plus( in_height = cn_lego_height_beam, in_margin = 0.0 )
+module plus( in_height = cn_lego_height_beam, in_margin = 0.0)
 {
     union()
 	{
@@ -92,7 +93,7 @@ module plus( in_height = cn_lego_height_beam, in_margin = 0.0 )
     }
 }
 
-module lego_beam( is_holes, in_height = cn_lego_height_beam, in_margin = 0.0  )
+module lego_beam( is_holes, in_height = cn_lego_height_beam, in_margin = 0.0)
 {
 	//number of studs
 	in_length = len(is_holes);


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
This PR moves openscad rendering precision to global variables so that they can be overwritten by calling script. This fixes an issue where calling `lego_beam` results in poor precision because the precision parameter is not exposed.

**NOTE**: This PR is a differential of #5 so should be merged *after* that PR.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
